### PR TITLE
Handle some or all token networks

### DIFF
--- a/pathfinder/cli.py
+++ b/pathfinder/cli.py
@@ -7,18 +7,32 @@ monkey.patch_all()  # isort:skip # noqa
 import logging
 import os
 import sys
+from typing import List
 
 import click
 from raiden_libs.blockchain import BlockchainListener
 from raiden_libs.contracts import ContractManager
 from web3 import HTTPProvider, Web3
+from eth_utils import is_checksum_address
 
 import pathfinder
 from pathfinder.no_ssl_patch import no_ssl_verification
 from pathfinder.pathfinding_service import PathfindingService
 from pathfinder.transport import MatrixTransport
+from pathfinder.utils.types import Address
 
 log = logging.getLogger(__name__)
+
+
+def check_supplied_token_network_addresses(token_network_addresses: List[str]) -> List[Address]:
+    result = []
+    for address in token_network_addresses:
+        if not is_checksum_address(address):
+            log.error(f"Token Network address '{address}' is not a checksum address. Ignoring.")
+        else:
+            result.append(address)
+
+    return result
 
 
 @click.command()
@@ -50,22 +64,34 @@ log = logging.getLogger(__name__)
     required=True,
     help='Matrix password'
 )
+@click.argument(
+    'token_network_addresses',
+    nargs=-1
+)
 def main(
     eth_rpc,
     monitoring_channel,
     matrix_homeserver,
     matrix_username,
-    matrix_password
+    matrix_password,
+    token_network_addresses,
 ):
     """Console script for pathfinder."""
 
     # setup logging
     logging.basicConfig(level=logging.INFO)
-    logging.getLogger('urllib3.connectionpool').setLevel(logging.DEBUG)
+    # logging.getLogger('urllib3.connectionpool').setLevel(logging.DEBUG)
 
     log.info("Starting Raiden Pathfinding Service")
 
+    token_network_addresses = check_supplied_token_network_addresses(token_network_addresses)
+    if token_network_addresses:
+        log.info('Following {} networks.')
+    else:
+        log.info('Following all networks.')
+
     with no_ssl_verification():
+        service = None
         try:
             log.info('Starting Matrix Transport...')
             transport = MatrixTransport(
@@ -82,22 +108,43 @@ def main(
             contracts_path = os.path.join(module_dir, 'contract', 'contracts_12032018.json')
             contract_manager = ContractManager(contracts_path)
 
-            log.info('Starting Blockchain Monitor...')
-            listener = BlockchainListener(
+            log.info('Starting TokenNetwork Listener...')
+            token_network_listener = BlockchainListener(
                 web3,
                 contract_manager,
                 'TokenNetwork',
             )
 
             log.info('Starting Pathfinding Service...')
-            service = PathfindingService(transport, listener)
+            if token_network_addresses:
+                service = PathfindingService(
+                    web3,
+                    contract_manager,
+                    transport,
+                    token_network_listener,
+                    follow_networks=token_network_addresses)
+            else:
+                log.info('Starting TokenNetworkRegistry Listener...')
+                token_network_registry_listener = BlockchainListener(
+                    web3,
+                    contract_manager,
+                    'TokenNetworkRegistry',
+                )
+
+                service = PathfindingService(
+                    web3,
+                    contract_manager,
+                    transport,
+                    token_network_listener,
+                    token_network_registry_listener=token_network_registry_listener)
 
             service.run()
         except (KeyboardInterrupt, SystemExit):
             print('Exiting...')
         finally:
-            log.info('Stopping Pathfinding Service...')
-            service.stop()
+            if service:
+                log.info('Stopping Pathfinding Service...')
+                service.stop()
 
     return 0
 

--- a/pathfinder/tests/fixtures/core.py
+++ b/pathfinder/tests/fixtures/core.py
@@ -2,6 +2,8 @@ from typing import List
 from unittest.mock import Mock
 
 import pytest
+from raiden_libs.contracts import ContractManager
+from web3 import Web3
 
 from pathfinder.contract.token_network_contract import TokenNetworkContract
 from pathfinder.pathfinding_service import PathfindingService
@@ -17,11 +19,18 @@ def token_networks(token_network_contracts: List[TokenNetworkContract]) -> List[
 
 
 @pytest.fixture
-def pathfinding_service(token_networks: List[TokenNetwork]) -> PathfindingService:
+def pathfinding_service(
+    web3: Web3,
+    contract_manager: ContractManager,
+    token_networks: List[TokenNetwork]
+) -> PathfindingService:
     # TODO: replace with a pathfinding service that actually syncs with the tester chain.
     pathfinding_service = PathfindingService(
+        web3,
+        contract_manager,
         transport=Mock(),
-        blockchain_listener=Mock()
+        token_network_listener=Mock(),
+        token_network_registry_listener=Mock()
     )
     pathfinding_service.token_networks = {
         token_network.address: token_network

--- a/pathfinder/tests/test_pathfinder.py
+++ b/pathfinder/tests/test_pathfinder.py
@@ -8,9 +8,29 @@ from click.testing import CliRunner
 from pathfinder import cli
 
 
-def test_command_line_interface():
+def test_cli_help():
     """Test the CLI."""
     runner = CliRunner()
     help_result = runner.invoke(cli.main, ['--help'])
     assert help_result.exit_code == 0
     assert 'Show this message and exit.' in help_result.output
+
+
+def test_cli_matrix_required():
+    """Test the CLI."""
+    runner = CliRunner()
+    result = runner.invoke(cli.main)
+
+    assert result.exit_code == 2
+    assert 'Missing option "--matrix-username".' in result.output
+
+
+def test_cli_matrix_required2():
+    """Test the CLI."""
+    runner = CliRunner()
+    result = runner.invoke(cli.main, [
+        '--matrix-username', 'xxx',
+    ])
+
+    assert result.exit_code == 2
+    assert 'Missing option "--matrix-password".' in result.output


### PR DESCRIPTION
Token networks can be whitelisted by passing them as an argument on the command line:
```
pathfinder 0xnetwork1 0xnetwork2
```

If no networks are whitelisted the PFS will listen to `TokenNetworkCreated` events and follow new networks.