### PR TITLE
Add an integration test based on mocked objects.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 # Config file for automatic testing at travis-ci.org
 
-sudo: required
 language: python
 python: 3.6
 cache: pip

--- a/pathfinder/pathfinding_service.py
+++ b/pathfinder/pathfinding_service.py
@@ -36,9 +36,20 @@ class PathfindingService(gevent.Greenlet):
         transport: MatrixTransport,
         token_network_listener: BlockchainListener,
         *,
-        token_network_registry_listener: BlockchainListener = None,
         follow_networks: List[Address] = None,
+        token_network_registry_listener: BlockchainListener = None,
     ) -> None:
+        """ Creates a new pathfinding service
+
+        Args:
+            web3: A web3 client
+            contract_manager: A contract manager
+            transport: A transport object
+            token_network_listener: A blockchain listener object
+            follow_networks: A list of token network addresses to follow. This has precedence over
+                the `token_network_registry_listener`
+            token_network_registry_listener: A blockchain listener object for the network registry
+        """
         super().__init__()
         self.web3 = web3
         self.contract_manager = contract_manager
@@ -124,7 +135,7 @@ class PathfindingService(gevent.Greenlet):
             participant1 = event['args']['participant1']
             participant2 = event['args']['participant2']
 
-            token_network.handle_channel_opened(
+            token_network.handle_channel_opened_event(
                 channel_identifier,
                 participant1,
                 participant2

--- a/pathfinder/tests/fixtures/network_service.py
+++ b/pathfinder/tests/fixtures/network_service.py
@@ -1,12 +1,14 @@
 import random
+
 from typing import List
 from unittest.mock import Mock
 import pytest
 from coincurve import PrivateKey
 from eth_utils import remove_0x_prefix
+from web3 import Web3
 from raiden_contracts.contract_manager import ContractManager
 from raiden_libs.utils import EMPTY_MERKLE_ROOT, private_key_to_address
-from web3 import Web3
+from raiden_libs.test.mocks.blockchain import BlockchainListenerMock
 
 from pathfinder.model.balance_proof import BalanceProof
 from pathfinder.pathfinding_service import PathfindingService
@@ -181,5 +183,22 @@ def pathfinding_service(
         token_network.address: token_network
         for token_network in token_networks
     }
+
+    return pathfinding_service
+
+
+@pytest.fixture
+def pathfinding_service_mocked_listeners(
+        web3: Web3,
+        contracts_manager: ContractManager,
+) -> PathfindingService:
+    """ Returns a PathfindingService with mocked blockchain listeners. """
+    pathfinding_service = PathfindingService(
+        web3,
+        contracts_manager,
+        transport=Mock(),
+        token_network_listener=BlockchainListenerMock(),
+        token_network_registry_listener=BlockchainListenerMock()
+    )
 
     return pathfinding_service

--- a/pathfinder/tests/test_mocked_integration.py
+++ b/pathfinder/tests/test_mocked_integration.py
@@ -1,0 +1,335 @@
+# -*- coding: utf-8 -*-
+from typing import List
+
+from unittest.mock import Mock
+from web3 import Web3
+from raiden_contracts.contract_manager import ContractManager
+from raiden_libs.test.mocks.blockchain import BlockchainListenerMock
+
+from pathfinder.token_network import TokenNetwork
+from pathfinder.pathfinding_service import PathfindingService
+from pathfinder.utils.types import Address
+
+
+def test_pathfinding_service_with_mocked_events(
+    token_networks: List[TokenNetwork],  # just used for addresses
+    addresses: List[Address],
+    pathfinding_service_mocked_listeners: PathfindingService
+):
+    network_listener = pathfinding_service_mocked_listeners.token_network_listener
+    registry_listener = pathfinding_service_mocked_listeners.token_network_registry_listener
+
+    token_network_address = token_networks[0].address
+
+    # this is a new Pathfinding Service, there should be no token networks registered
+    assert len(pathfinding_service_mocked_listeners.token_networks.keys()) == 0
+
+    # emit a TokenNetworkCreated event
+    registry_listener.emit_event(dict(
+        name='TokenNetworkCreated',
+        args=dict(
+            token_network_address=token_network_address
+        )
+    ))
+
+    # now there should be a token network registered
+    assert token_network_address in pathfinding_service_mocked_listeners.token_networks
+    token_network = pathfinding_service_mocked_listeners.token_networks[token_network_address]
+
+    # Now initialize some channels in this network.
+    # The tuples in channel_descriptions define the following:
+    # (
+    #     p1_index,
+    #     p1_deposit,
+    #     p1_transferred_amount,
+    #     p1_fee,
+    #     p2_index,
+    #     p2_deposit,
+    #     p2_transferred_amount,
+    #     p2_fee
+    # )
+    # Topology:
+    #       /-------------\
+    # 0 -- 1 -- 2 -- 3 -- 4    5 -- 6
+    #  \-------/
+
+    channel_descriptions = [
+        (0, 100,  20, 0.0010, 1,  50,  10, 0.0015),  # capacities  90 --  60
+        (1,  40,  10, 0.0008, 2, 130, 100, 0.0012),  # capacities 130 --  40
+        (2,  90,  10, 0.0007, 3,   0,   0, 0.0010),  # capacities  80 --  10
+        (3,  50,  20, 0.0011, 4,  50,  20, 0.0011),  # capacities  50 --  50
+        (0,  40,  40, 0.0015, 2,  80,   0, 0.0025),  # capacities   0 -- 120
+        (1,  30,  10, 0.0100, 4,  40,  15, 0.0018),  # capacities  35 --  35
+        (5, 500, 900, 0.0030, 6, 750, 950, 0.0040),  # capacities 550 -- 700
+    ]
+    for channel_id, (
+        p1_index,
+        p1_deposit,
+        p1_transferred_amount,
+        p1_fee,
+        p2_index,
+        p2_deposit,
+        p2_transferred_amount,
+        p2_fee
+    ) in enumerate(channel_descriptions):
+        network_listener.emit_event(dict(
+            address=token_network_address,
+            name='ChannelOpened',
+            args=dict(
+                channel_identifier=channel_id,
+                participant1=addresses[p1_index],
+                participant2=addresses[p2_index]
+            )
+        ))
+
+        network_listener.emit_event(dict(
+            address=token_network_address,
+            name='ChannelNewDeposit',
+            args=dict(
+                channel_identifier=channel_id,
+                participant=addresses[p1_index],
+                total_deposit=p1_deposit
+            )
+        ))
+
+        network_listener.emit_event(dict(
+            address=token_network_address,
+            name='ChannelNewDeposit',
+            args=dict(
+                channel_identifier=channel_id,
+                participant=addresses[p2_index],
+                total_deposit=p2_deposit
+            )
+        ))
+
+    # now there should be seven channels
+    assert len(token_network.channel_id_to_addresses.keys()) == 7
+
+    # Now close all channels
+    for channel_id, (
+        p1_index,
+        p1_deposit,
+        p1_transferred_amount,
+        p1_fee,
+        p2_index,
+        p2_deposit,
+        p2_transferred_amount,
+        p2_fee
+    ) in enumerate(channel_descriptions):
+        network_listener.emit_event(dict(
+            address=token_network_address,
+            name='ChannelClosed',
+            args=dict(
+                channel_identifier=channel_id,
+                closing_participant=addresses[p1_index]
+            )
+        ))
+
+    # there should be no channels
+    assert len(token_network.channel_id_to_addresses.keys()) == 0
+
+
+def test_pathfinding_service_idempotency_of_channel_openings(
+    token_networks: List[TokenNetwork],  # just used for addresses
+    addresses: List[Address],
+    pathfinding_service_mocked_listeners: PathfindingService
+):
+    network_listener = pathfinding_service_mocked_listeners.token_network_listener
+    registry_listener = pathfinding_service_mocked_listeners.token_network_registry_listener
+
+    token_network_address = token_networks[0].address
+
+    # this is a new Pathfinding Service, there should be no token networks registered
+    assert len(pathfinding_service_mocked_listeners.token_networks.keys()) == 0
+
+    # emit a TokenNetworkCreated event
+    registry_listener.emit_event(dict(
+        name='TokenNetworkCreated',
+        args=dict(
+            token_network_address=token_network_address
+        )
+    ))
+
+    # now there should be a token network registered
+    assert token_network_address in pathfinding_service_mocked_listeners.token_networks
+    token_network = pathfinding_service_mocked_listeners.token_networks[token_network_address]
+
+    # create same channel 5 times
+    for _ in range(5):
+        network_listener.emit_event(dict(
+            address=token_network_address,
+            name='ChannelOpened',
+            args=dict(
+                channel_identifier=1,
+                participant1=addresses[0],
+                participant2=addresses[1]
+            )
+        ))
+
+    # now there should be seven channels
+    assert len(token_network.channel_id_to_addresses.keys()) == 1
+
+    # Now close the channel
+    network_listener.emit_event(dict(
+        address=token_network_address,
+        name='ChannelClosed',
+        args=dict(
+            channel_identifier=1,
+            closing_participant=addresses[0]
+        )
+    ))
+
+    # there should be no channels
+    assert len(token_network.channel_id_to_addresses.keys()) == 0
+
+
+def test_multiple_channels_for_2_participants_opened(
+    token_networks: List[TokenNetwork],  # just used for addresses
+    addresses: List[Address],
+    pathfinding_service_mocked_listeners: PathfindingService
+):
+    network_listener = pathfinding_service_mocked_listeners.token_network_listener
+    registry_listener = pathfinding_service_mocked_listeners.token_network_registry_listener
+
+    token_network_address = token_networks[0].address
+
+    # this is a new Pathfinding Service, there should be no token networks registered
+    assert len(pathfinding_service_mocked_listeners.token_networks.keys()) == 0
+
+    # emit a TokenNetworkCreated event
+    registry_listener.emit_event(dict(
+        name='TokenNetworkCreated',
+        args=dict(
+            token_network_address=token_network_address
+        )
+    ))
+
+    # now there should be a token network registered
+    assert token_network_address in pathfinding_service_mocked_listeners.token_networks
+    token_network = pathfinding_service_mocked_listeners.token_networks[token_network_address]
+
+    # create a channel
+    network_listener.emit_event(dict(
+        address=token_network_address,
+        name='ChannelOpened',
+        args=dict(
+            channel_identifier=1,
+            participant1=addresses[0],
+            participant2=addresses[1]
+        )
+    ))
+
+    # create a channel
+    network_listener.emit_event(dict(
+        address=token_network_address,
+        name='ChannelOpened',
+        args=dict(
+            channel_identifier=2,
+            participant1=addresses[1],
+            participant2=addresses[0]
+        )
+    ))
+
+    # now there should be two channels
+    assert len(token_network.channel_id_to_addresses.keys()) == 2
+
+    # now close one channel
+    network_listener.emit_event(dict(
+        address=token_network_address,
+        name='ChannelClosed',
+        args=dict(
+            channel_identifier=1,
+            closing_participant=addresses[0]
+        )
+    ))
+
+    # there should be one channel left
+    assert len(token_network.channel_id_to_addresses.keys()) == 1
+
+
+def test_events_from_unknown_token_network_ignored(
+    token_networks: List[TokenNetwork],  # just used for addresses
+    addresses: List[Address],
+    pathfinding_service_mocked_listeners: PathfindingService
+):
+    network_listener = pathfinding_service_mocked_listeners.token_network_listener
+    registry_listener = pathfinding_service_mocked_listeners.token_network_registry_listener
+
+    token_network_address = token_networks[0].address
+
+    # this is a new Pathfinding Service, there should be no token networks registered
+    assert len(pathfinding_service_mocked_listeners.token_networks.keys()) == 0
+
+    # emit a TokenNetworkCreated event
+    registry_listener.emit_event(dict(
+        name='TokenNetworkCreated',
+        args=dict(
+            token_network_address=token_network_address
+        )
+    ))
+
+    # now there should be a token network registered
+    assert token_network_address in pathfinding_service_mocked_listeners.token_networks
+    token_network = pathfinding_service_mocked_listeners.token_networks[token_network_address]
+
+    # create a channel for the network
+    network_listener.emit_event(dict(
+        address=token_network_address,
+        name='ChannelOpened',
+        args=dict(
+            channel_identifier=1,
+            participant1=addresses[0],
+            participant2=addresses[1]
+        )
+    ))
+
+    # now there should be a channel
+    assert len(token_network.channel_id_to_addresses.keys()) == 1
+
+    # now create a channel on a different token network
+    network_listener.emit_event(dict(
+        address=token_networks[1].address,
+        name='ChannelOpened',
+        args=dict(
+            channel_identifier=1,
+            participant1=addresses[0],
+            participant2=addresses[1]
+        )
+    ))
+
+    # there should still be one channel
+    assert len(token_network.channel_id_to_addresses.keys()) == 1
+
+
+def test_follow_networks_has_precedence(
+    web3: Web3,
+    contracts_manager: ContractManager,
+    token_networks: List[TokenNetwork]
+):
+    network_listener = BlockchainListenerMock()
+    registry_listener = BlockchainListenerMock()
+
+    pathfinding_service = PathfindingService(
+        web3,
+        contracts_manager,
+        transport=Mock(),
+        token_network_listener=network_listener,
+        follow_networks=[token_networks[0].address, token_networks[1].address],
+        token_network_registry_listener=registry_listener
+    )
+
+    token_network_address = token_networks[2].address
+
+    # two networks set in follow_networks, so there should be two networks
+    assert len(pathfinding_service.token_networks.keys()) == 2
+
+    # emit a TokenNetworkCreated event
+    registry_listener.emit_event(dict(
+        name='TokenNetworkCreated',
+        args=dict(
+            token_network_address=token_network_address
+        )
+    ))
+
+    # this shouldn't change
+    assert len(pathfinding_service.token_networks.keys()) == 2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,7 +10,7 @@ coverage>=4.5.1
 Sphinx>=1.7.1
 sphinx_rtd_theme>=0.2.4
 
-pytest
+pytest>=3.5.0
 pytest-runner
 ipython
 pdbpp


### PR DESCRIPTION
This also fixed one bug in the pathfinding service and can be extended
later.

This is faster than full integration tests and should be used for testing edge cases.