### PR TITLE
Check supplied network addresses for code before following.

### DIFF
--- a/pathfinder/pathfinding_service.py
+++ b/pathfinder/pathfinding_service.py
@@ -20,7 +20,7 @@ log = logging.getLogger(__name__)
 
 
 def error_handler(context, exc_info):
-    log.fatal("Unhandled exception terminating the program")
+    log.fatal("Unhandled exception. Terminating the program...")
     traceback.print_exception(
         etype=exc_info[0],
         value=exc_info[1],

--- a/pathfinder/tests/fixtures/network_service.py
+++ b/pathfinder/tests/fixtures/network_service.py
@@ -275,8 +275,8 @@ def populate_token_networks_case_2(
 
 @pytest.fixture
 def pathfinding_service_full_mock(
-        contracts_manager: ContractManager,
-        token_networks: List[TokenNetwork],
+    contracts_manager: ContractManager,
+    token_networks: List[TokenNetwork],
 ) -> PathfindingService:
     pathfinding_service = PathfindingService(
         contracts_manager,
@@ -293,7 +293,9 @@ def pathfinding_service_full_mock(
 
 
 @pytest.fixture
-def pathfinding_service_mocked_listeners(contracts_manager: ContractManager) -> PathfindingService:
+def pathfinding_service_mocked_listeners(
+    contracts_manager: ContractManager
+) -> PathfindingService:
     """ Returns a PathfindingService with mocked blockchain listeners. """
     pathfinding_service = PathfindingService(
         contracts_manager,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 Click>=6.0
 coincurve
 
-eth-tester[py-evm]>=0.1.0-beta.23,<1.0
 web3>=4.1.0,<5.0
 eth-utils>=1.0.1,<2.0.0
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -16,3 +16,5 @@ ipython
 pdbpp
 psutil
 numpy
+
+eth-tester[py-evm]>=0.1.0-beta.23,<1.0


### PR DESCRIPTION
Fixes #52.

This checks the token networks that are specified in the command line
contain code. if not they are ignored.